### PR TITLE
Implement datastore interface and sqlite datastore for local testing.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,12 @@
+module github.com/devsapp/serverless-stable-diffusion-api
+
+go 1.20
+
+require github.com/stretchr/testify v1.8.4
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/mattn/go-sqlite3 v1.14.17
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/mattn/go-sqlite3 v1.14.17 h1:mCRHCLDUBXgpKAqIKsaAaAsrAlbkeomtRFKXh2L6YIM=
+github.com/mattn/go-sqlite3 v1.14.17/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -1,0 +1,45 @@
+package datastore
+
+type DatastoreType int
+
+const (
+	SQLite DatastoreType = iota
+	MySQL
+	TableStore
+)
+
+type Config struct {
+	Type                 DatastoreType // the datastore type
+	DBName               string        // the database name
+	TableName            string
+	ColumnConfig         map[string]string // map of column name to column type
+	PrimaryKeyColumnName string
+}
+
+type Datastore interface {
+	// Put inserts or updates the column values in the datastore.
+	// It takes a key and a map of column names to values, and returns an error if the operation failed.
+	Put(key string, values map[string]interface{}) error
+
+	// Get retrieves the column values from the datastore.
+	// It takes a key and a slice of column names, and returns a map of column names to values,
+	// along with an error if the operation failed.
+	// If the key does not exist, the returned map and error are both nil.
+	Get(key string, columns []string) (map[string]interface{}, error)
+
+	//Put(key string, value string) error
+	//Get(key string) (string, error)
+
+	// Delete removes a value from the datastore.
+	// It takes a key, and returns an error if the operation failed.
+	// Note: delete a non-existent key will not return an error.
+	Delete(key string) error
+
+	// ListAll read all data from the datastore.
+	// It return a nested map, which means map[primaryKey]map[columanName]columanValue.
+	// Note: since it reads all data and store them in memory, so do not call this function on a large datastore.
+	ListAll() (map[string]map[string]interface{}, error)
+
+	// Close close the datastore.
+	Close() error
+}

--- a/pkg/datastore/sqlite.go
+++ b/pkg/datastore/sqlite.go
@@ -1,0 +1,162 @@
+package datastore
+
+import (
+	"database/sql"
+	"fmt"
+	"reflect"
+	"strings"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+type SQLiteDatastore struct {
+	db     *sql.DB
+	config *Config
+}
+
+func NewSQLiteDatastore(config *Config) *SQLiteDatastore {
+	db, err := sql.Open("sqlite3", config.DBName)
+	if err != nil {
+		panic(fmt.Errorf("failed to open database: %v", err))
+	}
+
+	// Create table if it doesn't exist.
+	columnDefs := make([]string, 0, len(config.ColumnConfig))
+	for name, typ := range config.ColumnConfig {
+		columnDefs = append(columnDefs, fmt.Sprintf("%s %s", name, typ))
+	}
+	query := fmt.Sprintf(
+		"CREATE TABLE IF NOT EXISTS %s (%s)",
+		config.TableName,
+		strings.Join(columnDefs, ", "),
+	)
+	_, err = db.Exec(query)
+	if err != nil {
+		panic(fmt.Errorf("failed to create table %s: %v", config.TableName, err))
+	}
+	return &SQLiteDatastore{
+		db:     db,
+		config: config,
+	}
+}
+
+func (ds *SQLiteDatastore) Close() error {
+	return ds.db.Close()
+}
+
+func (ds *SQLiteDatastore) Get(key string, columns []string) (map[string]interface{}, error) {
+	row := ds.db.QueryRow(
+		fmt.Sprintf("SELECT %s FROM %s WHERE %s = ?",
+			strings.Join(columns, ", "), ds.config.TableName, ds.config.PrimaryKeyColumnName),
+		key,
+	)
+
+	// Prepare a slice to hold the values.
+	values := make([]interface{}, len(columns))
+	for i, column := range columns {
+		// We use the type information stored in the Config to create a variable of the correct type.
+		var value interface{}
+		switch ds.config.ColumnConfig[column] {
+		case "text":
+			value = new(string)
+		case "int":
+			// For simplicity, we use int64 for all integers.
+			value = new(int64)
+		case "float":
+			value = new(float64)
+		default:
+			// If the column type is not supported, we return an error.
+			return nil, fmt.Errorf("unsupported column type: %s", ds.config.ColumnConfig[column])
+		}
+		values[i] = value
+	}
+
+	// Scan the result into the values slice.
+	err := row.Scan(values...)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			// There is no row with the given key.
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	// Prepare the result map and fill it with values.
+	result := make(map[string]interface{})
+	for i, column := range columns {
+		// We use the reflect package to dereference the pointer.
+		value := reflect.ValueOf(values[i]).Elem().Interface()
+		result[column] = value
+	}
+
+	return result, nil
+}
+
+func (ds *SQLiteDatastore) Put(key string, values map[string]interface{}) error {
+	columns := []string{ds.config.PrimaryKeyColumnName}
+	placeholders := []string{"?"}
+	args := []interface{}{key}
+	for column, value := range values {
+		columns = append(columns, column)
+		placeholders = append(placeholders, "?")
+		args = append(args, value)
+	}
+	query := fmt.Sprintf(
+		"INSERT OR REPLACE INTO %s (%s) VALUES (%s)",
+		ds.config.TableName,
+		strings.Join(columns, ", "),
+		strings.Join(placeholders, ", "),
+	)
+	_, err := ds.db.Exec(query, args...)
+	return err
+}
+
+func (ds *SQLiteDatastore) Delete(key string) error {
+	_, err := ds.db.Exec(
+		fmt.Sprintf(
+			"DELETE FROM %s WHERE %s = ?", ds.config.TableName, ds.config.PrimaryKeyColumnName),
+		key)
+	return err
+}
+
+func (ds *SQLiteDatastore) ListAll() (map[string]map[string]interface{}, error) {
+	rows, err := ds.db.Query(fmt.Sprintf("SELECT * FROM %s", ds.config.TableName))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+
+	results := make(map[string]map[string]interface{})
+	for rows.Next() {
+		columns := make([]interface{}, len(cols))
+		columnPointers := make([]interface{}, len(cols))
+		for i := range columns {
+			columnPointers[i] = &columns[i]
+		}
+
+		err := rows.Scan(columnPointers...)
+		if err != nil {
+			return nil, err
+		}
+
+		m := make(map[string]interface{})
+		for i, colName := range cols {
+			val := columnPointers[i].(*interface{})
+			m[colName] = *val
+		}
+
+		key := m[ds.config.PrimaryKeyColumnName].(string)
+		results[key] = m
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}

--- a/pkg/datastore/sqlite_test.go
+++ b/pkg/datastore/sqlite_test.go
@@ -1,0 +1,121 @@
+package datastore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSQLiteDatastore(t *testing.T) {
+	primaryKeyColumnName := "primaryKey"
+	config := &Config{
+		DBName:    ":memory:", // the memory database for testing purposes
+		TableName: "TestSQLiteDatastore",
+		ColumnConfig: map[string]string{
+			primaryKeyColumnName: "text primary key not null",
+			"value":              "text",
+			"intCol":             "int",
+			"floatCol":           "float",
+		},
+		PrimaryKeyColumnName: primaryKeyColumnName,
+	}
+	ds := NewSQLiteDatastore(config)
+	defer ds.Close()
+
+	key := "testKey"
+	value := "testValue"
+	intValue := 123
+	floatValue := 123.45
+
+	// Test Put.
+	err := ds.Put(key, map[string]interface{}{"value": value, "intCol": intValue, "floatCol": floatValue})
+	assert.NoError(t, err)
+
+	// Test Get.
+	result, err := ds.Get(key, []string{"value", "intCol", "floatCol"})
+	assert.NoError(t, err)
+	assert.Equal(t, value, result["value"].(string))
+	assert.Equal(t, int64(intValue), result["intCol"].(int64))
+	assert.Equal(t, floatValue, result["floatCol"].(float64))
+
+	// Test Delete.
+	err = ds.Delete(key)
+	assert.NoError(t, err)
+
+	// Test that the key is indeed deleted.
+	result, err = ds.Get(key, []string{"value", "intCol", "floatCol"})
+	assert.NoError(t, err)
+	assert.Nil(t, result)
+
+	// Test deleting a non-existent key.
+	err = ds.Delete("non-existent key")
+	assert.NoError(t, err)
+
+	// Test Put with non-existent column.
+	err = ds.Put(key, map[string]interface{}{"non_existent_column": value})
+	assert.Error(t, err)
+
+	// Test Put with wrong value type.
+	// Note: we do not expect wrong value type will result in error, since Go database/sql will try to convert it automatically.
+	err = ds.Put(key, map[string]interface{}{"value": 123, "intCol": "123", "floatCol": "123.45"})
+	assert.NoError(t, err)
+
+	// Test Get with non-existent column.
+	_, err = ds.Get(key, []string{"non_existent_column"})
+	assert.Error(t, err)
+
+	// Test Get with non-existent key.
+	_, err = ds.Get("non-existent key", []string{"value", "intCol", "floatCol"})
+	assert.NoError(t, err)
+}
+
+func TestListAll(t *testing.T) {
+	primaryKeyColumnName := "primaryKey"
+	config := &Config{
+		DBName:    ":memory:", // the memory database for testing purposes
+		TableName: "TestListAll",
+		ColumnConfig: map[string]string{
+			primaryKeyColumnName: "text primary key not null",
+			"value":              "text",
+			"intCol":             "int",
+			"floatCol":           "float",
+		},
+		PrimaryKeyColumnName: primaryKeyColumnName,
+	}
+	ds := NewSQLiteDatastore(config)
+	defer ds.Close()
+
+	// Insert some test data.
+	testData := map[string]map[string]interface{}{
+		"key1": {"value": "value1", "intCol": 1, "floatCol": 1.1},
+		"key2": {"value": "value2", "intCol": 2, "floatCol": 2.2},
+		"key3": {"value": "value3", "intCol": 3, "floatCol": 3.3},
+	}
+	for k, v := range testData {
+		err := ds.Put(k, v)
+		assert.NoError(t, err)
+	}
+
+	// Call ListAll and check the result.
+	result, err := ds.ListAll()
+	assert.NoError(t, err)
+	for k, v := range testData {
+		r, ok := result[k]
+		assert.True(t, ok)
+		assert.Equal(t, v["value"], r["value"].(string))
+		assert.Equal(t, int64(v["intCol"].(int)), r["intCol"].(int64))
+		assert.Equal(t, v["floatCol"].(float64), r["floatCol"].(float64))
+	}
+
+	// Delete all data.
+	for k := range testData {
+		err = ds.Delete(k)
+		assert.NoError(t, err)
+	}
+
+	// Call ListAll again and check the result.
+	result, err = ds.ListAll()
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(result))
+
+}


### PR DESCRIPTION
1. Abstract the datastore interface to support the different datastore, such as mysql, tablestore.
2. Implement the sqlite datastore for local testing.